### PR TITLE
Cmake betterment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ find_package(BLAS)
 if (NOT BLAS_FOUND)
 
   add_compile_definitions(BLAS_FOUND=0)
+else ()
+  add_compile_definitions(BLAS_FOUND=1)
+
 endif()
 
 add_subdirectory(ori_ken)

--- a/ori_ken/include/cblas.h
+++ b/ori_ken/include/cblas.h
@@ -1,0 +1,9 @@
+extern "C" {
+    enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102};
+    enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
+    void cblas_dgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
+                 const int K, const double alpha, const double *A,
+                 const int lda, const double *B, const int ldb,
+                 const double beta, double *C, const int ldc);
+}

--- a/ori_ken/include/lapacke.h
+++ b/ori_ken/include/lapacke.h
@@ -1,0 +1,9 @@
+extern "C" {
+    enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102};
+    enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
+    void cblas_dgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
+                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
+                 const int K, const double alpha, const double *A,
+                 const int lda, const double *B, const int ldb,
+                 const double beta, double *C, const int ldc);
+}

--- a/ori_ken/include/lapacke.h
+++ b/ori_ken/include/lapacke.h
@@ -1,9 +1,5 @@
 extern "C" {
-    enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102};
-    enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
-    void cblas_dgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
-                 const enum CBLAS_TRANSPOSE TransB, const int M, const int N,
-                 const int K, const double alpha, const double *A,
-                 const int lda, const double *B, const int ldb,
-                 const double beta, double *C, const int ldc);
+    #define LAPACK_ROW_MAJOR               101
+    #define LAPACK_COL_MAJOR               102
+    int LAPACKE_dgesdd(int, char,int,int,double*,int,double*,double*,int,double*,int);
 }

--- a/ori_ken/tests/CMakeLists.txt
+++ b/ori_ken/tests/CMakeLists.txt
@@ -1,14 +1,23 @@
 add_executable(verification verification_tests.cpp)
-target_link_libraries(verification PRIVATE ori_ken)
-target_include_directories(verification PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../ori_ken/include>
-  $<INSTALL_INTERFACE:include>
-)
+add_executable(st simple_test.cpp)
 
 find_package(LAPACK)
 if(LAPACK_FOUND AND BLAS_FOUND)
-   set(lapackblas_libraries ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
-   target_link_libraries(verification ${lapackblas_libraries})
-endif()
+  set(lapackblas_libraries ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+  target_link_libraries(verification ${lapackblas_libraries} ori_ken)
+else()
+  target_link_libraries(verification PRIVATE ori_ken)
+  target_include_directories(verification PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<INSTALL_INTERFACE:include>
+  )
+  
+  endif()
+  target_link_libraries(st PRIVATE ori_ken)
+  target_include_directories(st PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<INSTALL_INTERFACE:include>
+  )
 
 add_test(verification verification)
+add_test(st st)

--- a/ori_ken/tests/simple_test.cpp
+++ b/ori_ken/tests/simple_test.cpp
@@ -1,0 +1,5 @@
+#include <cassert>
+int main(){
+    assert(true);
+    return 0;
+}


### PR DESCRIPTION
I believe I fixed the issue where tests would not build and be ran easily. They should have been compiled with make but I am not sure why they didn't. I added a line in the tests cmake file so that the executables in the test folders are considered tests. I can confirm this library works both with and without lapack and blas. It is weird that cmake finds lapack before I add it in as a module, but it only find the header files after I add lapack as a module.